### PR TITLE
rebrands nedit to xnedit in error strings and dialogs

### DIFF
--- a/source/calltips.c
+++ b/source/calltips.c
@@ -205,7 +205,7 @@ static char *expandAllTabs( char *text, int tab_width ) {
     textCpy = (char*)NEditMalloc( len + 1 );
     if( !textCpy ) {
         fprintf(stderr, 
-                "nedit: Out of heap memory in expandAllTabs!\n");
+                "xnedit: Out of heap memory in expandAllTabs!\n");
         return NULL;
     }
     

--- a/source/file.c
+++ b/source/file.c
@@ -1179,7 +1179,7 @@ int SaveWindowAs(WindowInfo *window, FileSelection *file)
     if (otherWindow != NULL)
     {
         response = DialogF(DF_WARN, window->shell, 2, "File open",
-        "%s is open in another NEdit window", "Cancel",
+        "%s is open in another XNEdit window", "Cancel",
         "Close Other Window", filename);
 
         if (response == 1)

--- a/source/highlight.c
+++ b/source/highlight.c
@@ -1432,7 +1432,7 @@ static void incrementalReparse(windowHighlightData *highlightData,
 	    	    max(endAt, max(lastModified(styleBuf), lastMod)));
 	    if (IS_PLAIN(parseInStyle)) {
 		fprintf(stderr,
-			"NEdit internal error: incr. reparse fell short\n");
+			"XNEdit internal error: incr. reparse fell short\n");
 		return;
 	    }
 	    parseInStyle = parentStyleOf(parentStyles, parseInStyle);

--- a/source/highlightData.c
+++ b/source/highlightData.c
@@ -1271,7 +1271,7 @@ static void convertPatternExpr(char **patternRE, char *patSetName,
     } else{
 	newRE = ConvertRE(*patternRE, &errorText);
 	if (newRE == NULL) {
-	    fprintf(stderr, "NEdit error converting old format regular "
+	    fprintf(stderr, "XNEdit error converting old format regular "
 		    "expression in pattern set %s, pattern %s: %s\n",
 		    patSetName, patName, errorText);
 	} 
@@ -1756,7 +1756,7 @@ void EditHighlightStyles(const char *initialStyle)
     /* Create a form widget in an application shell */
     ac = 0;
     XtSetArg(args[ac], XmNdeleteResponse, XmDO_NOTHING); ac++;
-    XtSetArg(args[ac], XmNiconName, "NEdit Text Drawing Styles"); ac++;
+    XtSetArg(args[ac], XmNiconName, "XNEdit Text Drawing Styles"); ac++;
     XtSetArg(args[ac], XmNtitle, "Text Drawing Styles"); ac++;
     HSDialog.shell = CreateWidget(TheAppShell, "textStyles",
 	    topLevelShellWidgetClass, args, ac);
@@ -2339,7 +2339,7 @@ void EditHighlightPatterns(WindowInfo *window)
     /* Create a form widget in an application shell */
     n = 0;
     XtSetArg(args[n], XmNdeleteResponse, XmDO_NOTHING); n++;
-    XtSetArg(args[n], XmNiconName, "NEdit Highlight Patterns"); n++;
+    XtSetArg(args[n], XmNiconName, "XNEdit Highlight Patterns"); n++;
     XtSetArg(args[n], XmNtitle, "Syntax Highlighting Patterns"); n++;
     HighlightDialog.shell = CreateWidget(TheAppShell, "syntaxHighlight",
 	    topLevelShellWidgetClass, args, n);

--- a/source/interpret.c
+++ b/source/interpret.c
@@ -794,7 +794,7 @@ Symbol *PromoteToGlobal(Symbol *sym)
         /* case a)
            just make this symbol a GLOBAL_SYM symbol and return */
         fprintf(stderr,
-                "nedit: To boldly go where no local sym has gone before: %s\n",
+                "xnedit: To boldly go where no local sym has gone before: %s\n",
                 sym->name);
         sym->type = GLOBAL_SYM;
         return sym;
@@ -802,7 +802,7 @@ Symbol *PromoteToGlobal(Symbol *sym)
         /* case b)
            sym will shadow the old symbol from the GlobalSymList */
         fprintf(stderr,
-                "nedit: duplicate symbol in LocalSymList and GlobalSymList: %s\n",
+                "xnedit: duplicate symbol in LocalSymList and GlobalSymList: %s\n",
                 sym->name);
     }
 

--- a/source/macro.c
+++ b/source/macro.c
@@ -749,7 +749,7 @@ void Replay(WindowInfo *window)
         prog = ParseMacro(ReplayMacro, &errMsg, &stoppedAt);
         if (prog == NULL) {
             fprintf(stderr,
-                "NEdit internal error, learn/replay macro syntax error: %s\n",
+                "XNEdit internal error, learn/replay macro syntax error: %s\n",
                 errMsg);
             return;
         }
@@ -1480,7 +1480,7 @@ selEnd += $text_length - startLength\n}\n";
     /* Parse the resulting macro into an executable program "prog" */
     prog = ParseMacro(loopedCmd, &errMsg, &stoppedAt);
     if (prog == NULL) {
-	fprintf(stderr, "NEdit internal error, repeat macro syntax wrong: %s\n",
+	fprintf(stderr, "XNEdit internal error, repeat macro syntax wrong: %s\n",
     		errMsg);
     	return;
     }

--- a/source/menu.c
+++ b/source/menu.c
@@ -2731,7 +2731,7 @@ static void newAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
             openInTab = !openInTab;
         }
         else {
-            fprintf(stderr, "nedit: Unknown argument to action procedure \"new\": %s\n", args[0]);
+            fprintf(stderr, "xnedit: Unknown argument to action procedure \"new\": %s\n", args[0]);
         }
     }
     
@@ -2791,7 +2791,7 @@ static void openAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     char *enc = NULL;
     
     if (*nArgs == 0) {
-    	fprintf(stderr, "nedit: open action requires file argument\n");
+    	fprintf(stderr, "xnedit: open action requires file argument\n");
     	return;
     }
     if(*nArgs > 1) {
@@ -2885,7 +2885,7 @@ static void saveAsDialogAP(Widget w, XEvent *event, String *args,
 static void saveAsAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
-    	fprintf(stderr, "nedit: save_as action requires file argument\n");
+    	fprintf(stderr, "xnedit: save_as action requires file argument\n");
     	return;
     }
     FileSelection file;
@@ -2960,7 +2960,7 @@ static void includeAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     if (CheckReadOnly(window))
     	return;
     if (*nArgs == 0) {
-    	fprintf(stderr, "nedit: include action requires file argument\n");
+    	fprintf(stderr, "xnedit: include action requires file argument\n");
     	return;
     }
     IncludeFile(WidgetToWindow(w), args[0]);
@@ -2985,7 +2985,7 @@ static void loadMacroDialogAP(Widget w, XEvent *event, String *args,
 static void loadMacroAP(Widget w, XEvent *event, String *args, Cardinal *nArgs) 
 {
     if (*nArgs == 0) {
-    	fprintf(stderr,"nedit: load_macro_file action requires file argument\n");
+    	fprintf(stderr,"xnedit: load_macro_file action requires file argument\n");
     	return;
     }
     ReadMacroFile(WidgetToWindow(w), args[0], True);
@@ -3010,7 +3010,7 @@ static void loadTagsDialogAP(Widget w, XEvent *event, String *args,
 static void loadTagsAP(Widget w, XEvent *event, String *args, Cardinal *nArgs) 
 {
     if (*nArgs == 0) {
-    	fprintf(stderr,"nedit: load_tags_file action requires file argument\n");
+    	fprintf(stderr,"xnedit: load_tags_file action requires file argument\n");
     	return;
     }
 
@@ -3026,7 +3026,7 @@ static void unloadTagsAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
 	fprintf(stderr,
-		"nedit: unload_tags_file action requires file argument\n");
+		"xnedit: unload_tags_file action requires file argument\n");
 	return;
     }
     
@@ -3067,7 +3067,7 @@ static void loadTipsDialogAP(Widget w, XEvent *event, String *args,
 static void loadTipsAP(Widget w, XEvent *event, String *args, Cardinal *nArgs) 
 {
     if (*nArgs == 0) {
-    	fprintf(stderr,"nedit: load_tips_file action requires file argument\n");
+    	fprintf(stderr,"xnedit: load_tips_file action requires file argument\n");
     	return;
     }
 
@@ -3083,7 +3083,7 @@ static void unloadTipsAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
 	fprintf(stderr,
-		"nedit: unload_tips_file action requires file argument\n");
+		"xnedit: unload_tips_file action requires file argument\n");
 	return;
     }
     /* refresh the "Unload Calltips File" tear-offs after unloading, or 
@@ -3250,7 +3250,7 @@ static void findDialogAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 static void findAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
-    	fprintf(stderr, "nedit: find action requires search string argument\n");
+    	fprintf(stderr, "xnedit: find action requires search string argument\n");
     	return;
     }
     SearchAndSelect(WidgetToWindow(w), searchDirection(1, args, nArgs), args[0],
@@ -3280,7 +3280,7 @@ static void findIncrAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     int i, continued = FALSE;
     if (*nArgs == 0) {
-    	fprintf(stderr, "nedit: find action requires search string argument\n");
+    	fprintf(stderr, "xnedit: find action requires search string argument\n");
     	return;
     }
     for (i=1; i<(int)*nArgs; i++)
@@ -3311,7 +3311,7 @@ static void replaceAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     	return;
     if (*nArgs < 2) {
     	fprintf(stderr,
-    	"nedit: replace action requires search and replace string arguments\n");
+    	"xnedit: replace action requires search and replace string arguments\n");
     	return;
     }
     SearchAndReplace(window, searchDirection(2, args, nArgs),
@@ -3327,7 +3327,7 @@ static void replaceAllAP(Widget w, XEvent *event, String *args,
     	return;
     if (*nArgs < 2) {
     	fprintf(stderr,
-    "nedit: replace_all action requires search and replace string arguments\n");
+    "xnedit: replace_all action requires search and replace string arguments\n");
     	return;
     }
     ReplaceAll(window, args[0], args[1], searchType(2, args, nArgs));
@@ -3342,7 +3342,7 @@ static void replaceInSelAP(Widget w, XEvent *event, String *args,
     	return;
     if (*nArgs < 2) {
     	fprintf(stderr,
-  "nedit: replace_in_selection requires search and replace string arguments\n");
+  "xnedit: replace_in_selection requires search and replace string arguments\n");
     	return;
     }
     ReplaceInSelection(window, args[0], args[1],
@@ -3404,7 +3404,7 @@ static void gotoAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
             || (*nArgs == 2
                 && (!StringToNum(args[0], &lineNum)
                     || !StringToNum(args[1], &column)))) {
-        fprintf(stderr,"nedit: goto_line_number action requires line and/or column number\n");
+        fprintf(stderr,"xnedit: goto_line_number action requires line and/or column number\n");
         return;
     }
 
@@ -3453,7 +3453,7 @@ static void repeatMacroAP(Widget w, XEvent *event, String *args,
     int how;
     
     if (*nArgs != 2) {
-    	fprintf(stderr, "nedit: repeat_macro requires two arguments\n");
+    	fprintf(stderr, "xnedit: repeat_macro requires two arguments\n");
     	return;
     }
     if (!strcmp(args[0], "in_selection"))
@@ -3461,7 +3461,7 @@ static void repeatMacroAP(Widget w, XEvent *event, String *args,
     else if (!strcmp(args[0], "to_end"))
 	how = REPEAT_TO_END;
     else if (sscanf(args[0], "%d", &how) != 1) {
-    	fprintf(stderr, "nedit: repeat_macro requires method/count\n");
+    	fprintf(stderr, "xnedit: repeat_macro requires method/count\n");
     	return;
     }
     RepeatMacro(WidgetToWindow(w), args[1], how);
@@ -3471,7 +3471,7 @@ static void markAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0 || strlen(args[0]) != 1 || 
       	    !isalnum((unsigned char)args[0][0])) {
-    	fprintf(stderr,"nedit: mark action requires a single-letter label\n");
+    	fprintf(stderr,"xnedit: mark action requires a single-letter label\n");
     	return;
     }
     AddMark(WidgetToWindow(w), w, args[0][0]);
@@ -3488,7 +3488,7 @@ static void gotoMarkAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     if (*nArgs == 0 || strlen(args[0]) != 1 || 
       	    !isalnum((unsigned char)args[0][0])) {
      	fprintf(stderr,
-     	    	"nedit: goto_mark action requires a single-letter label\n");
+     	    	"xnedit: goto_mark action requires a single-letter label\n");
      	return;
     }
     GotoMark(WidgetToWindow(w), w, args[0][0], *nArgs > 1 &&
@@ -3703,7 +3703,7 @@ static void shellFilterAP(Widget w, XEvent *event, String *args,
     	return;
     if (*nArgs == 0) {
     	fprintf(stderr,
-    		"nedit: filter_selection requires shell command argument\n");
+    		"xnedit: filter_selection requires shell command argument\n");
     	return;
     }
     FilterSelection(window, args[0],
@@ -3742,7 +3742,7 @@ static void execAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     	return;
     if (*nArgs == 0) {
     	fprintf(stderr,
-    		"nedit: execute_command requires shell command argument\n");
+    		"xnedit: execute_command requires shell command argument\n");
     	return;
     }
     ExecShellCommand(window, args[0],
@@ -3762,7 +3762,7 @@ static void shellMenuAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
     	fprintf(stderr,
-    		"nedit: shell_menu_command requires item-name argument\n");
+    		"xnedit: shell_menu_command requires item-name argument\n");
     	return;
     }
     HidePointerOnKeyedEvent(w, event);
@@ -3775,7 +3775,7 @@ static void macroMenuAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
     	fprintf(stderr,
-    		"nedit: macro_menu_command requires item-name argument\n");
+    		"xnedit: macro_menu_command requires item-name argument\n");
     	return;
     }
     /* Don't allow users to execute a macro command from the menu (or accel)
@@ -3802,7 +3802,7 @@ static void bgMenuAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 {
     if (*nArgs == 0) {
     	fprintf(stderr,
-    		"nedit: bg_menu_command requires item-name argument\n");
+    		"xnedit: bg_menu_command requires item-name argument\n");
     	return;
     }
     /* Same remark as for macro menu commands (see above). */
@@ -3991,7 +3991,7 @@ static void focusPaneAP(Widget w, XEvent *event, String *args,
         }
     }
     else {
-        fprintf(stderr, "nedit: focus_pane requires argument\n");
+        fprintf(stderr, "xnedit: focus_pane requires argument\n");
     }
 }
 
@@ -4003,7 +4003,7 @@ static void focusPaneAP(Widget w, XEvent *event, String *args,
             (newState) = (intState != 0); \
         } \
         else { \
-            fprintf(stderr, "nedit: %s requires 0 or 1 argument\n", actionName); \
+            fprintf(stderr, "xnedit: %s requires 0 or 1 argument\n", actionName); \
             return; \
         } \
     } \
@@ -4068,11 +4068,11 @@ static void setAutoIndentAP(Widget w, XEvent *event, String *args,
             SetAutoIndent(window, SMART_INDENT);
         }
         else {
-            fprintf(stderr, "nedit: set_auto_indent invalid argument\n");
+            fprintf(stderr, "xnedit: set_auto_indent invalid argument\n");
         }
     }
     else {
-        fprintf(stderr, "nedit: set_auto_indent requires argument\n");
+        fprintf(stderr, "xnedit: set_auto_indent requires argument\n");
     }
 }
 
@@ -4091,11 +4091,11 @@ static void setWrapTextAP(Widget w, XEvent *event, String *args,
             SetAutoWrap(window, CONTINUOUS_WRAP);
         }
         else {
-            fprintf(stderr, "nedit: set_wrap_text invalid argument\n");
+            fprintf(stderr, "xnedit: set_wrap_text invalid argument\n");
         }
     }
     else {
-        fprintf(stderr, "nedit: set_wrap_text requires argument\n");
+        fprintf(stderr, "xnedit: set_wrap_text requires argument\n");
     }
 }
 
@@ -4118,11 +4118,11 @@ static void setWrapMarginAP(Widget w, XEvent *event, String *args,
         }
         else {
             fprintf(stderr,
-                "nedit: set_wrap_margin requires integer argument >= 0 and < 1000\n");
+                "xnedit: set_wrap_margin requires integer argument >= 0 and < 1000\n");
         }
     }
     else {
-        fprintf(stderr, "nedit: set_wrap_margin requires argument\n");
+        fprintf(stderr, "xnedit: set_wrap_margin requires argument\n");
     }
 }
 
@@ -4198,11 +4198,11 @@ static void setShowMatchingAP(Widget w, XEvent *event, String *args,
            SetShowMatching(window, FLASH_DELIMIT);
         }
         else {
-            fprintf(stderr, "nedit: Invalid argument for set_show_matching\n");
+            fprintf(stderr, "xnedit: Invalid argument for set_show_matching\n");
         }
     }
     else {
-        fprintf(stderr, "nedit: set_show_matching requires argument\n");
+        fprintf(stderr, "xnedit: set_show_matching requires argument\n");
     }
 }
 
@@ -4264,12 +4264,12 @@ static void setTabDistAP(Widget w, XEvent *event, String *args,
         }
         else {
             fprintf(stderr,
-                "nedit: set_tab_dist requires integer argument > 0 and <= %d\n",
+                "xnedit: set_tab_dist requires integer argument > 0 and <= %d\n",
                 MAX_EXP_CHAR_LEN);
         }
     }
     else {
-        fprintf(stderr, "nedit: set_tab_dist requires argument\n");
+        fprintf(stderr, "xnedit: set_tab_dist requires argument\n");
     }
 }
 
@@ -4289,11 +4289,11 @@ static void setEmTabDistAP(Widget w, XEvent *event, String *args,
         }
         else {
             fprintf(stderr,
-                "nedit: set_em_tab_dist requires integer argument >= -1 and < 1000\n");
+                "xnedit: set_em_tab_dist requires integer argument >= -1 and < 1000\n");
         }
     }
     else {
-        fprintf(stderr, "nedit: set_em_tab_dist requires integer argument\n");
+        fprintf(stderr, "xnedit: set_em_tab_dist requires integer argument\n");
     }
 }
 
@@ -4316,7 +4316,7 @@ static void setFontsAP(Widget w, XEvent *event, String *args,
         SetFonts(window, args[0], args[1], args[2], args[3]);
     }
     else {
-        fprintf(stderr, "nedit: set_fonts requires 4 arguments\n");
+        fprintf(stderr, "xnedit: set_fonts requires 4 arguments\n");
     }
 }
 
@@ -4329,7 +4329,7 @@ static void setLanguageModeAP(Widget w, XEvent *event, String *args,
         SetLanguageMode(window, FindLanguageMode(args[0]), FALSE);
     }
     else {
-        fprintf(stderr, "nedit: set_language_mode requires argument\n");
+        fprintf(stderr, "xnedit: set_language_mode requires argument\n");
     }
 }
 
@@ -4905,7 +4905,7 @@ void WriteNEditDB(void)
     FILE *fp;
     int i;
     static char fileHeader[] =
-            "# File name database for NEdit Open Previous command\n";
+            "# File name database for XNEdit Open Previous command\n";
 
     if (fullName == NULL) {
         /*  GetRCFileName() might return NULL if an error occurs during
@@ -5014,7 +5014,7 @@ void ReadNEditDB(void)
         /*  stat() failed, probably for non-exiting history database.  */
         if (ENOENT != errno)
         {
-            perror("nedit: Error reading history database");
+            perror("xnedit: Error reading history database");
         }
         return;
     }
@@ -5049,7 +5049,7 @@ void ReadNEditDB(void)
         }
         if (line[lineLen - 1] != '\n') {
             /* no newline, probably truncated */
-            fprintf(stderr, "nedit: Line too long in history file\n");
+            fprintf(stderr, "xnedit: Line too long in history file\n");
             while (fgets(line, sizeof(line), fp) != NULL) {
                 lineLen = strlen(line);
                 if (lineLen > 0 && line[lineLen - 1] == '\n') {
@@ -5061,7 +5061,7 @@ void ReadNEditDB(void)
         line[--lineLen] = '\0';
         if (strcspn(line, neditDBBadFilenameChars) != lineLen) {
             /* non-filename characters */
-            fprintf(stderr, "nedit: History file may be corrupted\n");
+            fprintf(stderr, "xnedit: History file may be corrupted\n");
             continue;
         }
         nameCopy = NEditStrdup(line);
@@ -5525,7 +5525,7 @@ static void shortMenusCB(Widget w, WindowInfo *window, caddr_t callData)
 static void addToToggleShortList(Widget w)
 {
     if (ShortMenuWindow->nToggleShortItems >= MAX_SHORTENED_ITEMS) {
-    	fprintf(stderr,"nedit, internal error: increase MAX_SHORTENED_ITEMS\n");
+    	fprintf(stderr,"xnedit, internal error: increase MAX_SHORTENED_ITEMS\n");
     	return;
     }
     ShortMenuWindow->toggleShortItems[ShortMenuWindow->nToggleShortItems++] = w;

--- a/source/nedit.c
+++ b/source/nedit.c
@@ -155,7 +155,7 @@ static char *fallbackResources[] = {
        groups the fonts into the right classes.  It's then easier for
        the user or environment to override this sensibly:
 
-         nedit -xrm '*textFontList: myfont'
+         xnedit -xrm '*textFontList: myfont'
 
        This is broken in recent versions of LessTif.
 
@@ -416,6 +416,10 @@ static const char cmdLineHelp[] =
 "[Sorry, no on-line help available.]\n"; /* Why is that ? */
 #endif /*VMS*/
 
+/* This constant will be used in preference keys. Hence, for now we do not
+ * change it for maintaining backwards compatibility to NEdit preferences
+ * TODO: maybe we should decouple AppName and preference keys
+ */
 static char *XNEditAppName = "nedit";
 
 char* GetAppName(void)
@@ -447,7 +451,7 @@ int main(int argc, char **argv)
     }
 
     if (stability == MotifKnownBad) {
-        fputs("nedit: WARNING: This version of NEdit is built incorrectly, and will be unstable.\n",
+        fputs("xnedit: WARNING: This version of XNEdit is built incorrectly, and will be unstable.\n",
               stderr);
 #ifndef BUILD_BROKEN_NEDIT
     /* Dear maintainers who are patching this; please have mercy on your users and link against 
@@ -456,7 +460,7 @@ int main(int argc, char **argv)
 #endif
     }
 
-    /* Save the command which was used to invoke nedit for restart command */
+    /* Save the command which was used to invoke xnedit for restart command */
     ArgV0 = argv[0];
     
     for (i=1; i<argc; i++) {
@@ -559,7 +563,7 @@ int main(int argc, char **argv)
                 exit(EXIT_SUCCESS);
             }
         }
-	fputs ("NEdit: Can't open display\n", stderr);
+	fputs ("XNEdit: Can't open display\n", stderr);
 	exit(EXIT_FAILURE);
     }
     
@@ -662,7 +666,7 @@ int main(int argc, char **argv)
 	} else if (opts && !strcmp(argv[i], "-tags")) {
     	    nextArg(argc, argv, &i);
     	    if (!AddTagsFile(argv[i], TAG))
-    	    	fprintf(stderr, "NEdit: Unable to load tags file\n");
+    	    	fprintf(stderr, "XNEdit: Unable to load tags file\n");
     	} else if (opts && !strcmp(argv[i], "-do")) {
     	    nextArg(argc, argv, &i);
 	    if (checkDoMacroArg(argv[i]))
@@ -683,13 +687,13 @@ int main(int argc, char **argv)
     	    nextArg(argc, argv, &i);
 	    nRead = sscanf(argv[i], "%d", &lineNum);
 	    if (nRead != 1)
-    		fprintf(stderr, "NEdit: argument to line should be a number\n");
+    		fprintf(stderr, "XNEdit: argument to line should be a number\n");
     	    else
     	    	gotoLine = True;
     	} else if (opts && (*argv[i] == '+')) {
     	    nRead = sscanf((argv[i]+1), "%d", &lineNum);
 	    if (nRead != 1)
-    		fprintf(stderr, "NEdit: argument to + should be a number\n");
+    		fprintf(stderr, "XNEdit: argument to + should be a number\n");
     	    else
     	    	gotoLine = True;
     	} else if (opts && !strcmp(argv[i], "-server")) {
@@ -724,7 +728,7 @@ int main(int argc, char **argv)
 #ifdef VMS
 	    *argv[i] = '/';
 #endif /*VMS*/
-    	    fprintf(stderr, "nedit: Unrecognized option %s\n%s", argv[i],
+    	    fprintf(stderr, "xnedit: Unrecognized option %s\n%s", argv[i],
     	    	    cmdLineHelp);
     	    exit(EXIT_FAILURE);
     	} else {
@@ -790,7 +794,7 @@ int main(int argc, char **argv)
 		    if (window)
     	    		lastFile = window;
                 } else {
-		    fprintf(stderr, "nedit: file name too long: %s\n", nameList[j]);
+		    fprintf(stderr, "xnedit: file name too long: %s\n", nameList[j]);
                 }
 		free(nameList[j]);
 	    }
@@ -847,7 +851,7 @@ int main(int argc, char **argv)
 		if (window)
     	    	    lastFile = window;
 	    } else {
-		fprintf(stderr, "nedit: file name too long: %s\n", argv[i]);
+		fprintf(stderr, "xnedit: file name too long: %s\n", argv[i]);
 	    }
 #endif /*VMS*/
 
@@ -909,7 +913,7 @@ static void nextArg(int argc, char **argv, int *argIndex)
 #ifdef VMS
 	    *argv[*argIndex] = '/';
 #endif /*VMS*/
-    	fprintf(stderr, "NEdit: %s requires an argument\n%s", argv[*argIndex],
+    	fprintf(stderr, "XNEdit: %s requires an argument\n%s", argv[*argIndex],
     	        cmdLineHelp);
     	exit(EXIT_FAILURE);
     }

--- a/source/preferences.c
+++ b/source/preferences.c
@@ -1370,7 +1370,7 @@ void SaveNEditPrefs(Widget parent, int quietly)
                 ImportedFile == NULL ?
                 "Default preferences will be saved in the file:\n"
                 "%s\n"
-                "NEdit automatically loads this file\n"
+                "XNEdit automatically loads this file\n"
                 "each time it is started." :
                 "Default preferences will be saved in the file:\n"
                 "%s\n"
@@ -2134,7 +2134,7 @@ int CheckPrefsChangesSaved(Widget dialogParent)
     resp = DialogF(DF_WARN, dialogParent, 3, "Default Preferences",
             ImportedFile == NULL ?
             "Default Preferences have changed.\n"
-            "Save changes to NEdit preference file?" :
+            "Save changes to XNEdit preference file?" :
             "Default Preferences have changed.  SAVING \n"
             "CHANGES WILL INCORPORATE ADDITIONAL\nSETTINGS FROM FILE: %s",
             "Save", "Don't Save", "Cancel", ImportedFile);
@@ -2791,7 +2791,7 @@ static void shellSelOKCB(Widget widget, XtPointer clientData,
 
     /*  Leave with a warning if the dialog is not up.  */
     if (!XtIsRealized(shellSelDialog)) {
-        fprintf(stderr, "nedit: Callback shellSelOKCB() illegally called.\n");
+        fprintf(stderr, "xnedit: Callback shellSelOKCB() illegally called.\n");
         return;
     }
 
@@ -2852,7 +2852,7 @@ void EditLanguageModes(void)
     /* Create a form widget in an application shell */
     ac = 0;
     XtSetArg(args[ac], XmNdeleteResponse, XmDO_NOTHING); ac++;
-    XtSetArg(args[ac], XmNiconName, "NEdit Language Modes"); ac++;
+    XtSetArg(args[ac], XmNiconName, "XNEdit Language Modes"); ac++;
     XtSetArg(args[ac], XmNtitle, "Language Modes"); ac++;
     LMDialog.shell = CreateWidget(TheAppShell, "langModes",
 	    topLevelShellWidgetClass, args, ac);
@@ -3622,7 +3622,7 @@ static languageModeRec *readLMDialogFields(int silent)
             return NULL;
         } else
             if (DeleteTagsFile(lm->defTipsFile, TIP, False) == FALSE)
-                fprintf(stderr, "nedit: Internal error: Trouble deleting " 
+                fprintf(stderr, "xnedit: Internal error: Trouble deleting " 
                         "calltips file(s):\n  \"%s\"\n", lm->defTipsFile);
     }
     
@@ -5147,7 +5147,7 @@ int ParseError(Widget toDialog, const char *stringStart, const char *stoppedAt,
     errorLine[len] = '\0';
     if (toDialog == NULL)
     {
-        fprintf(stderr, "NEdit: %s in %s:\n%s\n", message, errorIn, errorLine);
+        fprintf(stderr, "XNEdit: %s in %s:\n%s\n", message, errorIn, errorLine);
     } else
     {
         DialogF(DF_WARN, toDialog, 1, "Parse Error", "%s in %s:\n%s", "OK",
@@ -6378,7 +6378,7 @@ static const char* getDefaultShell(void)
     if (NULL == passwdEntry)
     {
         /*  Something bad happened! Do something, quick!  */
-        perror("nedit: Failed to get passwd entry (falling back to 'sh')");
+        perror("xnedit: Failed to get passwd entry (falling back to 'sh')");
         return "sh";
     }
 

--- a/source/regexConvert.c
+++ b/source/regexConvert.c
@@ -972,6 +972,6 @@ static void reg_error (char *str) {
 
    fprintf (
       stderr,
-      "NEdit: Internal error processing regular expression (%s)\n",
+      "XNEdit: Internal error processing regular expression (%s)\n",
       str);
 }

--- a/source/regularExp.c
+++ b/source/regularExp.c
@@ -4131,7 +4131,7 @@ static void reg_error (char *str) {
 
    fprintf (
       stderr,
-      "nedit: Internal error processing regular expression (%s)\n",
+      "xnedit: Internal error processing regular expression (%s)\n",
       str);
 }
 

--- a/source/search.c
+++ b/source/search.c
@@ -576,7 +576,7 @@ static void getSelectionCB(Widget w, XtPointer si, Atom *selection,
     /* return an empty string if the data is not of the correct format. */
     if (*format != 8) {
         DialogF(DF_WARN, window->shell, 1, "Invalid Format",
-                "NEdit can't handle non 8-bit text", "OK");
+                "XNEdit can't handle non 8-bit text", "OK");
         NEditFree(value);
         selectionInfo->selection = 0;
         selectionInfo->done = 1;
@@ -2869,7 +2869,7 @@ static void selectedSearchCB(Widget w, XtPointer callData, Atom *selection,
     }
     /* should be of type text??? */
     if (*format != 8) {
-    	fprintf(stderr, "NEdit: can't handle non 8-bit text\n");
+    	fprintf(stderr, "XNEdit: can't handle non 8-bit text\n");
     	XBell(TheDisplay, 0);
 	NEditFree(value);
         NEditFree(callData);

--- a/source/selection.c
+++ b/source/selection.c
@@ -209,7 +209,7 @@ static void gotoCB(Widget widget, XtPointer wi, Atom *sel,
     }
     /* should be of type text??? */
     if (*format != 8) {
-    	fprintf(stderr, "NEdit: Can't handle non 8-bit text\n");
+        fprintf(stderr, "XNEdit: Can't handle non 8-bit text\n");
     	XBell(TheDisplay, 0);
 	NEditFree(value);
 	return;
@@ -278,7 +278,7 @@ static void fileCB(Widget widget, XtPointer wi, Atom *sel,
     }
     /* should be of type text??? */
     if (*format != 8) {
-    	fprintf(stderr, "NEdit: Can't handle non 8-bit text\n");
+        fprintf(stderr, "XNEdit: Can't handle non 8-bit text\n");
     	XBell(TheDisplay, 0);
 	NEditFree(value);
 	return;

--- a/source/server.c
+++ b/source/server.c
@@ -458,7 +458,7 @@ static void processServerCommandString(char *string)
 	editFlags = (readFlag ? PREF_READ_ONLY : 0) | CREATE |
 		(createFlag ? SUPPRESS_CREATE_WARN : 0);
 	if (ParseFilename(fullname, filename, pathname) != 0) {
-	   fprintf(stderr, "NEdit: invalid file name\n");
+	   fprintf(stderr, "XNEdit: invalid file name\n");
            deleteFileClosedProperty2(filename, pathname);
 	   break;
 	}
@@ -542,6 +542,6 @@ static void processServerCommandString(char *string)
     return;
 
 readError:
-    fprintf(stderr, "NEdit: error processing server request\n");
+    fprintf(stderr, "XNEdit: error processing server request\n");
     return;
 }

--- a/source/shell.c
+++ b/source/shell.c
@@ -510,12 +510,12 @@ static void issueCommand(WindowInfo *window, const char *command, char *input,
     
     /* set the pipes connected to the process for non-blocking i/o */
     if (fcntl(stdinFD, F_SETFL, O_NONBLOCK) < 0)
-    	perror("nedit: Internal error (fcntl)");
+    	perror("xnedit: Internal error (fcntl)");
     if (fcntl(stdoutFD, F_SETFL, O_NONBLOCK) < 0)
-    	perror("nedit: Internal error (fcntl1)");
+    	perror("xnedit: Internal error (fcntl1)");
     if (flags & ERROR_DIALOGS) {
 	if (fcntl(stderrFD, F_SETFL, O_NONBLOCK) < 0)
-    	    perror("nedit: Internal error (fcntl2)");
+    	    perror("xnedit: Internal error (fcntl2)");
     }
     
     /* if there's nothing to write to the process' stdin, close it now */
@@ -594,7 +594,7 @@ static void stdoutReadProc(XtPointer clientData, int *source, XtInputId *id)
     /* error in read */
     if (nRead == -1) { /* error */
 	if (errno != EWOULDBLOCK && errno != EAGAIN) {
-	    perror("nedit: Error reading shell command output");
+	    perror("xnedit: Error reading shell command output");
 	    NEditFree(buf);
 	    finishCmdExecution(window, True);
 	}
@@ -635,7 +635,7 @@ static void stderrReadProc(XtPointer clientData, int *source, XtInputId *id)
     /* error in read */
     if (nRead == -1) {
 	if (errno != EWOULDBLOCK && errno != EAGAIN) {
-	    perror("nedit: Error reading shell command error stream");
+	    perror("xnedit: Error reading shell command error stream");
 	    NEditFree(buf);
 	    finishCmdExecution(window, True);
 	}
@@ -678,7 +678,7 @@ static void stdinWriteProc(XtPointer clientData, int *source, XtInputId *id)
     	    close(cmdData->stdinFD);
     	    cmdData->inPtr = NULL;
     	} else if (errno != EWOULDBLOCK && errno != EAGAIN) {
-    	    perror("nedit: Write to shell command failed");
+    	    perror("xnedit: Write to shell command failed");
     	    finishCmdExecution(window, True);
     	}
     } else {
@@ -776,7 +776,7 @@ static void flushTimeoutProc(XtPointer clientData, XtIntervalId *id)
 	    cmdData->leftPos += len;
 	    cmdData->rightPos = cmdData->leftPos;
 	} else
-	    fprintf(stderr, "nedit: Too much binary data\n");
+	    fprintf(stderr, "xnedit: Too much binary data\n");
     }
     NEditFree(outText);
 
@@ -901,7 +901,7 @@ static void finishCmdExecution(WindowInfo *window, int terminatedOnError)
     } else {
 	buf = TextGetBuffer(cmdData->textW);
 	if (!BufSubstituteNullChars(outText, outTextLen, buf)) {
-	    fprintf(stderr,"nedit: Too much binary data in shell cmd output\n");
+	    fprintf(stderr,"xnedit: Too much binary data in shell cmd output\n");
 	    outText[0] = '\0';
 	}
 	if (cmdData->flags & REPLACE_SELECTION) {
@@ -952,13 +952,13 @@ static pid_t forkCommand(Widget parent, const char *command, const char *cmdDir,
        returned to the caller, the other half is spliced to stdin, stdout
        and stderr in the child process */
     if (pipe(pipeFDs) != 0) {
-    	perror("nedit: Internal error (opening stdout pipe)");
+    	perror("xnedit: Internal error (opening stdout pipe)");
         return -1;
     }
     *stdoutFD = pipeFDs[0];
     childStdoutFD = pipeFDs[1];
     if (pipe(pipeFDs) != 0) {
-    	perror("nedit: Internal error (opening stdin pipe)");
+    	perror("xnedit: Internal error (opening stdin pipe)");
         return -1;
     }
     *stdinFD = pipeFDs[1];
@@ -967,7 +967,7 @@ static pid_t forkCommand(Widget parent, const char *command, const char *cmdDir,
     	childStderrFD = childStdoutFD;
     else {
 	if (pipe(pipeFDs) != 0) {
-    	    perror("nedit: Internal error (opening stdin pipe)");
+    	    perror("xnedit: Internal error (opening stdin pipe)");
             return -1;
         }
 	*stderrFD = pipeFDs[0];

--- a/source/tags.c
+++ b/source/tags.c
@@ -408,7 +408,7 @@ int AddTagsFile(const char *tagSpec, int file_type)
     
     /* To prevent any possible segfault */
     if (tagSpec == NULL) {
-        fprintf(stderr, "nedit: Internal Error!\n"
+        fprintf(stderr, "xnedit: Internal Error!\n"
                 "  Passed NULL pointer to AddTagsFile!\n");
         return FALSE;
     }
@@ -477,7 +477,7 @@ int DeleteTagsFile(const char *tagSpec, int file_type, Boolean force_unload)
     
     /* To prevent any possible segfault */
     if (tagSpec == NULL) {
-        fprintf(stderr, "nedit: Internal Error: Passed NULL pointer to DeleteTagsFile!\n");
+        fprintf(stderr, "xnedit: Internal Error: Passed NULL pointer to DeleteTagsFile!\n");
         return FALSE;
     }
     
@@ -1199,7 +1199,7 @@ static int findAllMatches(WindowInfo *window, const char *string)
     
     if (nMatches>1) {
         if (!(dupTagsList = (char **) NEditMalloc(sizeof(char *) * nMatches))) {
-            fprintf(stderr, "nedit: findAllMatches(): out of heap space!\n");
+            fprintf(stderr, "xnedit: findAllMatches(): out of heap space!\n");
             XBell(TheDisplay, 0);
             return -1;
         }
@@ -1224,7 +1224,7 @@ static int findAllMatches(WindowInfo *window, const char *string)
 
             if (NULL == (dupTagsList[i] = (char*) NEditMalloc(strlen(temp) + 1))) {
                 int j;
-                fprintf(stderr, "nedit: findAllMatches(): out of heap space!\n");
+                fprintf(stderr, "xnedit: findAllMatches(): out of heap space!\n");
 
                 /*  dupTagsList[i] is unallocated, let's free [i - 1] to [0]  */
                 for (j = i - 1; j > -1; j--) {
@@ -1635,7 +1635,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
             if (!status) 
                 return TF_ERROR_EOF;
             if (lineEmpty( line )) {
-                fprintf( stderr, "nedit: Warning: empty '* alias *' "
+                fprintf( stderr, "xnedit: Warning: empty '* alias *' "
                         "block in calltips file.\n" );
                 return TF_ERROR;
             }
@@ -1656,7 +1656,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
         /* Correct currLine for the empty line it read at the end */
         --(*currLine);
         if (incLines == 0) {
-            fprintf( stderr, "nedit: Warning: empty '* include *' or"
+            fprintf( stderr, "xnedit: Warning: empty '* include *' or"
                     " '* alias *' block in calltips file.\n" );
             return TF_ERROR;
         }
@@ -1692,7 +1692,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
         if (!status) 
             return TF_ERROR_EOF;
         if (lineEmpty( line )) {
-            fprintf( stderr, "nedit: Warning: empty '* language *' block in calltips file.\n" );
+            fprintf( stderr, "xnedit: Warning: empty '* language *' block in calltips file.\n" );
             return TF_ERROR;
         }
         *blkLine = *currLine;
@@ -1707,7 +1707,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
         if (!status) 
             return TF_ERROR_EOF;
         if (lineEmpty( line )) {
-            fprintf( stderr, "nedit: Warning: empty '* version *' block in calltips file.\n" );
+            fprintf( stderr, "xnedit: Warning: empty '* version *' block in calltips file.\n" );
             return TF_ERROR;
         }
         *blkLine = *currLine;
@@ -1726,7 +1726,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
         if (!status) 
             return TF_ERROR_EOF;
         if (lineEmpty( line )) {
-            fprintf( stderr, "nedit: Warning: empty calltip block:\n"
+            fprintf( stderr, "xnedit: Warning: empty calltip block:\n"
                      "   \"%s\"\n", header);
             return TF_ERROR;
         }
@@ -1745,7 +1745,7 @@ static int nextTFBlock(FILE *fp, char *header, char **body, int *blkLine,
     
     /* Warn about any unneeded extra lines (which are ignored). */
     if (dummy1+1 < *currLine && code != TF_BLOCK) {
-        fprintf( stderr, "nedit: Warning: extra lines in language or version block ignored.\n" );
+        fprintf( stderr, "xnedit: Warning: extra lines in language or version block ignored.\n" );
     }
     
     return code;
@@ -1810,7 +1810,7 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
     tf_alias *aliases=NULL, *tmp_alias;
     
     if(recLevel > MAX_TAG_INCLUDE_RECURSION_LEVEL) {
-        fprintf(stderr, "nedit: Warning: Reached recursion limit before loading calltips file:\n\t%s\n", tipsFile);
+        fprintf(stderr, "xnedit: Warning: Reached recursion limit before loading calltips file:\n\t%s\n", tipsFile);
         return 0;
     }
     
@@ -1837,7 +1837,7 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
     while( 1 ) {
         code = nextTFBlock(fp, header, &body, &blkLine, &currLine);
         if( code == TF_ERROR_EOF ) {
-            fprintf(stderr,"nedit: Warning: unexpected EOF in calltips file.\n");
+            fprintf(stderr,"xnedit: Warning: unexpected EOF in calltips file.\n");
             break;
         }
         if( code == TF_EOF ) 
@@ -1859,7 +1859,7 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
                 for(tipIncFile=strtok(body,":"); tipIncFile; 
                         tipIncFile=strtok(NULL,":")) {
                     /* fprintf(stderr,
-                        "nedit: DEBUG: including tips file '%s'\n",
+                        "xnedit: DEBUG: including tips file '%s'\n",
                         tipIncFile); */
                     nTipsAdded += loadTipsFile( tipIncFile, index, recLevel+1);
                 }
@@ -1873,14 +1873,14 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
                 if (langMode == PLAIN_LANGUAGE_MODE && 
                         strcmp(header, "Plain")) {
                     fprintf(stderr,
-                            "nedit: Error reading calltips file:\n\t%s\n"
+                            "xnedit: Error reading calltips file:\n\t%s\n"
                             "Unknown language mode: \"%s\"\n",
                             tipsFile, header);
                     langMode = oldLangMode;
                 }
                 break;
             case TF_ERROR:
-                fprintf(stderr,"nedit: Warning: Recoverable error while "
+                fprintf(stderr,"xnedit: Warning: Recoverable error while "
                         "reading calltips file:\n   \"%s\"\n",
                         resolvedTipsFile);
                 break;
@@ -1889,7 +1889,7 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
                 tmp_alias = aliases;
                 aliases = new_alias(header, body);
                 if( !aliases ) {
-                    fprintf(stderr,"nedit: Can't allocate memory for tipfile " 
+                    fprintf(stderr,"xnedit: Can't allocate memory for tipfile " 
                             "alias in calltips file:\n   \"%s\"\n",
                             resolvedTipsFile);
                     /* Deallocate any allocated aliases */
@@ -1912,7 +1912,7 @@ static int loadTipsFile(const char *tipsFile, int index, int recLevel)
         char *src;
         t = getTag(tmp_alias->dest, TIP);
         if (!t) {
-            fprintf(stderr, "nedit: Can't find destination of alias \"%s\"\n"
+            fprintf(stderr, "xnedit: Can't find destination of alias \"%s\"\n"
                     "  in calltips file:\n   \"%s\"\n",
                     tmp_alias->dest, resolvedTipsFile);
         } else {

--- a/source/textBuf.c
+++ b/source/textBuf.c
@@ -479,7 +479,7 @@ void BufInsertCol(textBuffer *buf, int column, int startPos, const char *text,
     insertCol(buf, column, lineStartPos, text, &insertDeleted, &nInserted,
     	    &buf->cursorPosHint);
     if (nDeleted != insertDeleted)
-    	fprintf(stderr, "NEdit internal consistency check ins1 failed");
+        fprintf(stderr, "XNEdit internal consistency check ins1 failed");
     callModifyCBs(buf, lineStartPos, nDeleted, nInserted, 0, deletedText);
     NEditFree(deletedText);
     if (charsInserted != NULL)
@@ -513,7 +513,7 @@ void BufOverlayRect(textBuffer *buf, int startPos, int rectStart,
     overlayRect(buf, lineStartPos, rectStart, rectEnd, text, &insertDeleted,
     	    &nInserted, &buf->cursorPosHint);
     if (nDeleted != insertDeleted)
-    	fprintf(stderr, "NEdit internal consistency check ovly1 failed");
+        fprintf(stderr, "XNEdit internal consistency check ovly1 failed");
     callModifyCBs(buf, lineStartPos, nDeleted, nInserted, 0, deletedText);
     NEditFree(deletedText);
     if (charsInserted != NULL)
@@ -908,7 +908,7 @@ void BufRemoveModifyCB(textBuffer *buf, bufModifyCallbackProc bufModifiedCB,
     	}
     }
     if (toRemove == -1) {
-    	fprintf(stderr, "NEdit Internal Error: Can't find modify CB to remove\n");
+        fprintf(stderr, "XNEdit Internal Error: Can't find modify CB to remove\n");
     	return;
     }
     
@@ -986,7 +986,7 @@ void BufRemovePreDeleteCB(textBuffer *buf, bufPreDeleteCallbackProc bufPreDelete
     	}
     }
     if (toRemove == -1) {
-    	fprintf(stderr, "NEdit Internal Error: Can't find pre-delete CB to remove\n");
+        fprintf(stderr, "XNEdit Internal Error: Can't find pre-delete CB to remove\n");
     	return;
     }
     

--- a/source/textDisp.c
+++ b/source/textDisp.c
@@ -1290,7 +1290,7 @@ void TextDMakeInsertPosVisible(textDisp *textD)
                     cursorPos, True);
     }
     if (topLine < 1) {
-        fprintf(stderr, "nedit: internal consistency check tl1 failed\n");
+        fprintf(stderr, "xnedit: internal consistency check tl1 failed\n");
         topLine = 1;
     }
     
@@ -1830,7 +1830,7 @@ static int posToVisibleLineNum(textDisp *textD, int pos, int *lineNum)
     	if (emptyLinesVisible(textD)) {
     	    if (textD->lastChar < textD->buffer->length) {
     		if (!posToVisibleLineNum(textD, textD->lastChar, lineNum)) {
-    		    fprintf(stderr, "nedit: Consistency check ptvl failed\n");
+    		    fprintf(stderr, "xnedit: Consistency check ptvl failed\n");
     		    return False;
     		}
     		return ++(*lineNum) <= textD->nVisibleLines-1;

--- a/source/userCmds.c
+++ b/source/userCmds.c
@@ -360,7 +360,7 @@ void EditShellMenu(WindowInfo *window)
     
     ac = 0;
     XtSetArg(args[ac], XmNdeleteResponse, XmDO_NOTHING); ac++;
-    XtSetArg(args[ac], XmNiconName, "NEdit Shell Menu"); ac++;
+    XtSetArg(args[ac], XmNiconName, "XNEdit Shell Menu"); ac++;
     XtSetArg(args[ac], XmNtitle, "Shell Menu"); ac++;
     ucd->dlogShell = CreateWidget(TheAppShell, "shellCommands",
 	    topLevelShellWidgetClass, args, ac);
@@ -2840,7 +2840,7 @@ static int loadMenuItemString(char *inString, menuItemRec **menuItems,
 
 static int parseError(const char *message)
 {
-    fprintf(stderr, "NEdit: Parse error in user defined menu item, %s\n",
+    fprintf(stderr, "XNEdit: Parse error in user defined menu item, %s\n",
     	    message);
     return False;
 }

--- a/util/fileUtils.c
+++ b/util/fileUtils.c
@@ -182,7 +182,7 @@ ExpandTilde(char *pathname)
     	passwdEntry = getpwuid(getuid());
 	if ((passwdEntry == NULL) || (*(passwdEntry->pw_dir)== '\0')) {
   	   /* This is really serious, so just exit. */
-           perror("NEdit/nc: getpwuid() failed ");
+           perror("XNEdit/nc: getpwuid() failed ");
            exit(EXIT_FAILURE);
 	}
     }

--- a/util/misc.c
+++ b/util/misc.c
@@ -2266,7 +2266,7 @@ long QueryDesktop(Display *display, Widget shell)
 */
 static void warning(const char* mesg)
 {
-  fprintf(stderr, "NEdit warning:\n%s\n", mesg);
+  fprintf(stderr, "XNEdit warning:\n%s\n", mesg);
 }
 
 /*

--- a/util/refString.c
+++ b/util/refString.c
@@ -160,7 +160,7 @@ void RefStringFree(const char *rcs_str)
         
         if (rp->usage < 0) /* D'OH! */
         {
-            fprintf(stderr, "NEdit: internal error deallocating shared string.");
+            fprintf(stderr, "XNEdit: internal error deallocating shared string.");
             return;
         }
 
@@ -176,7 +176,7 @@ void RefStringFree(const char *rcs_str)
     }
     else    /* Doesn't appear to be a shared string */
     {
-        fprintf(stderr, "NEdit: attempt to free a non-shared string.");
+        fprintf(stderr, "XNEdit: attempt to free a non-shared string.");
         return;
     }
 }


### PR DESCRIPTION
The term "NEdit Macro" has been excluded from rebranding for obvious reasons.

The `GetAppName()` function (and hence the `APP_NAME` macro) also use the string "nedit" for backwards compatibility.

Otherwise, (hopefully) all occurrences of nedit or NEdit in error messages and dialogs have been replaced with XNEdit (or xendit, respectively).