### PR TITLE
Bugfix/overflows

### DIFF
--- a/source/macro.c
+++ b/source/macro.c
@@ -1883,7 +1883,7 @@ static int focusWindowMS(WindowInfo *window, DataValue *argList, int nArgs,
     } else {
         /* just use the plain name as supplied */
 	for (w=WindowList; w != NULL; w = w->next) {
-	    sprintf(fullname, "%s%s", w->path, w->filename);
+	    snprintf(fullname, sizeof(fullname), "%s%s", w->path, w->filename);
 	    if (!strcmp(string, fullname)) {
 		break;
 	    }
@@ -1898,7 +1898,8 @@ static int focusWindowMS(WindowInfo *window, DataValue *argList, int nArgs,
                 return False;
             }
             for (w=WindowList; w != NULL; w = w->next) {
-                sprintf(fullname, "%s%s", w->path, w->filename);
+                snprintf(fullname, sizeof(fullname),
+                        "%s%s", w->path, w->filename);
                 if (!strcmp(normalizedString, fullname))
                     break;
             }
@@ -1922,8 +1923,9 @@ static int focusWindowMS(WindowInfo *window, DataValue *argList, int nArgs,
 
     /* Return the name of the window */
     result->tag = STRING_TAG;
-    AllocNString(&result->val.str, strlen(w->path)+strlen(w->filename)+1);
-    sprintf(result->val.str.rep, "%s%s", w->path, w->filename);
+    size_t result_str_len = strlen(w->path)+strlen(w->filename)+1;
+    AllocNString(&result->val.str, result_str_len);
+    snprintf(result->val.str.rep, result_str_len, "%s%s", w->path, w->filename);
     return True;
 }
 

--- a/source/macro.c
+++ b/source/macro.c
@@ -1863,7 +1863,7 @@ static int focusWindowMS(WindowInfo *window, DataValue *argList, int nArgs,
 {
     char stringStorage[TYPE_INT_STR_SIZE(int)], *string;
     WindowInfo *w;
-    char fullname[MAXPATHLEN];
+    char fullname[2*MAXPATHLEN];
     char normalizedString[MAXPATHLEN];
 
     /* Read the argument representing the window to focus to, and translate

--- a/source/menu.c
+++ b/source/menu.c
@@ -3126,7 +3126,7 @@ static void exitAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
     if (GetPrefWarnExit() && !(window == WindowList && window->next == NULL)) {
         int resp, titleLen, lineLen;
         char exitMsg[DF_MAX_MSG_LENGTH], *ptr, *title;
-	char filename[MAXPATHLEN];
+	char filename[MAXPATHLEN + 1];
         WindowInfo *win;
 
         /* List the windows being edited and make sure the

--- a/source/menu.c
+++ b/source/menu.c
@@ -3135,7 +3135,8 @@ static void exitAP(Widget w, XEvent *event, String *args, Cardinal *nArgs)
 	lineLen = 0;
         strcpy(ptr, "Editing: "); ptr += 9; lineLen += 9;
         for (win=WindowList; win!=NULL; win=win->next) {
-    	    sprintf(filename, "%s%s", win->filename, win->fileChanged? "*": "");
+    	    snprintf(filename, sizeof(filename),
+                    "%s%s", win->filename, win->fileChanged? "*": "");
 	    title = filename;
             titleLen = strlen(title);
             if (ptr - exitMsg + titleLen + 30 >= DF_MAX_MSG_LENGTH) {

--- a/source/search.c
+++ b/source/search.c
@@ -712,7 +712,8 @@ void CreateReplaceDlog(Widget parent, WindowInfo *window)
     form = CreateFormDialog(parent, "replaceDialog", args, argcnt);
     XtVaSetValues(form, XmNshadowThickness, 0, NULL);
     if (GetPrefKeepSearchDlogs()) {
-    	sprintf(title, "Replace/Find (in %s)", window->filename);
+    	snprintf(title, sizeof(title),
+                "Replace/Find (in %s)", window->filename);
     	XtVaSetValues(XtParent(form), XmNtitle, title, NULL);
     } else
     	XtVaSetValues(XtParent(form), XmNtitle, "Replace/Find", NULL);
@@ -1202,7 +1203,7 @@ void CreateFindDlog(Widget parent, WindowInfo *window)
     form = CreateFormDialog(parent, "findDialog", args, argcnt);
     XtVaSetValues(form, XmNshadowThickness, 0, NULL);
     if (GetPrefKeepSearchDlogs()) {
-    	sprintf(title, "Find (in %s)", window->filename);
+    	snprintf(title, sizeof(title), "Find (in %s)", window->filename);
     	XtVaSetValues(XtParent(form), XmNtitle, title, NULL);
     } else
     	XtVaSetValues(XtParent(form), XmNtitle, "Find", NULL);
@@ -1698,7 +1699,8 @@ static void rKeepCB(Widget w, WindowInfo *window, caddr_t *callData)
     window = WidgetToWindow(w);
 
     if (XmToggleButtonGetState(w)) {
-    	sprintf(title, "Replace/Find (in %s)", window->filename);
+    	snprintf(title, sizeof(title),
+                "Replace/Find (in %s)", window->filename);
     	XtVaSetValues(XtParent(window->replaceDlog), XmNtitle, title, NULL);
     } else
     	XtVaSetValues(XtParent(window->replaceDlog), XmNtitle, "Replace/Find", NULL);
@@ -1710,7 +1712,7 @@ static void fKeepCB(Widget w, WindowInfo *window, caddr_t *callData)
     window = WidgetToWindow(w);
 
     if (XmToggleButtonGetState(w)) {
-    	sprintf(title, "Find (in %s)", window->filename);
+    	snprintf(title, sizeof(title), "Find (in %s)", window->filename);
     	XtVaSetValues(XtParent(window->findDlog), XmNtitle, title, NULL);
     } else
     	XtVaSetValues(XtParent(window->findDlog), XmNtitle, "Find", NULL);
@@ -2064,9 +2066,9 @@ static void uploadFileListItems(WindowInfo* window, Bool replace)
     for (i = 0; i < nWritable; ++i) {
        w = window->writableWindows[i];
        if (usePathNames && window->filenameSet) {
-          sprintf(buf, "%s%s", w->path, w->filename);
+          snprintf(buf, sizeof(buf), "%s%s", w->path, w->filename);
        } else {
-          sprintf(buf, "%s", w->filename);
+          snprintf(buf, sizeof(buf), "%s", w->filename);
        }
        names[i] = XmStringCreateSimple(buf);
     }

--- a/source/search.c
+++ b/source/search.c
@@ -2045,7 +2045,7 @@ static void uploadFileListItems(WindowInfo* window, Bool replace)
 {
     XmStringTable names;
     int           nWritable, i, *selected, selectedCount;
-    char          buf[MAXPATHLEN+1], policy;
+    char          buf[2*MAXPATHLEN], policy;
     Bool          usePathNames;
     WindowInfo    *w;
     Widget        list;

--- a/source/window.c
+++ b/source/window.c
@@ -3671,7 +3671,7 @@ static int getTabPosition(Widget tab)
 void RefreshTabState(WindowInfo *win)
 {
     XmString s1, tipString;
-    char labelString[MAXPATHLEN];
+    char labelString[2*MAXPATHLEN+4];
     char *tag = XmFONTLIST_DEFAULT_TAG;
     unsigned char alignment;
 
@@ -4607,7 +4607,7 @@ void MoveDocumentDialog(WindowInfo *window)
 {
     WindowInfo *win, *targetWin, **shellWinList;
     int i, nList=0, nWindows=0, ac;
-    char tmpStr[MAXPATHLEN+50];
+    char tmpStr[2*MAXPATHLEN];
     Widget parent, dialog, listBox, moveAllOption;
     XmString *list = NULL;
     XmString popupTitle, s1;

--- a/source/window.c
+++ b/source/window.c
@@ -3679,11 +3679,11 @@ void RefreshTabState(WindowInfo *win)
        "*" (modified) will change per label alignment setting */
     XtVaGetValues(win->tab, XmNalignment, &alignment, NULL);
     if (alignment != XmALIGNMENT_END) {
-       sprintf(labelString, "%s%s",
+       snprintf(labelString, sizeof(labelString),"%s%s", 
                win->fileChanged? "*" : "",
                win->filename);
     } else {
-       sprintf(labelString, "%s%s",
+       snprintf(labelString, sizeof(labelString),"%s%s", 
                win->filename,
                win->fileChanged? "*" : "");
     }
@@ -4624,7 +4624,7 @@ void MoveDocumentDialog(WindowInfo *window)
 	if (!IsTopDocument(win) || win->shell == window->shell)
 	    continue;
 	
-	sprintf(tmpStr, "%s%s",
+	snprintf(tmpStr, sizeof(tmpStr), "%s%s",
 		win->filenameSet? win->path : "", win->filename);
 
 	list[nList] = XmStringCreateSimple(tmpStr);
@@ -4642,7 +4642,8 @@ void MoveDocumentDialog(WindowInfo *window)
     /* create the dialog */
     parent = window->shell;
     popupTitle = XmStringCreateSimple("Move Document");
-    sprintf(tmpStr, "Move %s into window of", window->filename);
+    snprintf(tmpStr, sizeof(tmpStr),
+            "Move %s into window of", window->filename);
     s1 = XmStringCreateSimple(tmpStr);
     ac = 0;
     XtSetArg(csdargs[ac], XmNdialogStyle, XmDIALOG_FULL_APPLICATION_MODAL); ac++;

--- a/util/fontsel.c
+++ b/util/fontsel.c
@@ -631,7 +631,7 @@ char* FontNameAddAttribute(
     
     if(b < len) {
         if(b > 0 && name[b-1] == ':') b--;
-        snprintf(newfont, newlen, "%.*s%.*s:%s=%s", b, name, len-e, name+e, attribute, value);
+        snprintf(newfont, newlen, "%.*s%.*s:%s=%s", b, name, (int)(len-e), name+e, attribute, value);
     } else {
         snprintf(newfont, newlen, "%s:%s=%s", name, attribute, value);
     }

--- a/util/printUtils.c
+++ b/util/printUtils.c
@@ -885,11 +885,12 @@ static int foundTag(const char *tagfilename, const char *tagname, char *result)
     tfile = fopen(tagfilename,"r");
     if (tfile != NULL) {
 	while (!feof(tfile)) {
-            fgets(line,sizeof(line),tfile);
-            if (sscanf(line,tagformat,result) != 0) {
-		fclose(tfile);
-        	return True;
-	    }
+            if (fgets(line,sizeof(line),tfile)) {
+                if (sscanf(line,tagformat,result) != 0) {
+                    fclose(tfile);
+                    return True;
+                }
+            }
 	}
 	fclose(tfile);
     }


### PR DESCRIPTION
Fixes some possible bugs due to overflows, unchecked return values or data type length mismatch.

I admit, that the overflow scenarios for the `sprintf()` calls are merely theoretical and the reason is primary a bad design issue in the nedit data structures, where `MAXPATHLEN` is used for both the path and the file name (instead of `PATH_MAX` for the path and `NAME_MAX` for the file name).

Hence, we are now reserving more memory than we would ever need in a real world scenario, but enough memory to accommodate for the actual buffer lengths.