### PR TITLE
update c++ highlight support

### DIFF
--- a/source/highlightData.c
+++ b/source/highlightData.c
@@ -243,7 +243,7 @@ static char *DefaultPatternSets[] = {
 	Gawk builtin variables:\"\"\"<(ARGIND|ERRNO|RT|IGNORECASE|FIELDWIDTHS)>\"\"\":::Storage Type::D\n\
 	Field:\"\\$[0-9a-zA-Z_]+|\\$[ \\t]*\\([^,;]*\\)\":::Storage Type::D\n\
 	BeginEnd:\"<(BEGIN|END)>\":::Preprocessor1::D\n\
-	Numeric constant:\"(?<!\\Y)((0(x|X)[0-9a-fA-F]*)|[0-9.]+((e|E)(\\+|-)?)?[0-9]*)(L|l|UL|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
+	Numeric constant:\"(?<!\\Y)((0(x|X)[0-9a-fA-F]*)|[0-9.]+((e|E)(\\+|-)?)?[0-9]*)(L|l|UL|ul|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
 	String pattern:\"~[ \\t]*\"\"\":\"\"\"\":\"\\n\":Preprocessor::\n\
 	String pattern escape:\"\\\\(.|\\n)\":::Preprocessor:String pattern:\n\
 	newline escape:\"\\\\$\":::Preprocessor1::\n\
@@ -260,7 +260,7 @@ static char *DefaultPatternSets[] = {
 	preprocessor string:\"(?:L|u|U|u8|R)?\"\"\":\"\"\"\":\"\\n\":Preprocessor1:preprocessor line:\n\
 	prepr string esc chars:\"\\\\(?:.|\\n)\":::String1:preprocessor string:\n\
 	preprocessor keywords:\"<__(?:LINE|FILE|DATE|TIME|STDC|STDC_HOSTED|func)__>\":::Preprocessor::\n\
-	numeric constant:\"(?<!\\Y)(?:(?:0(?:x|X)[0-9a-fA-F][0-9a-fA-F']*)|(?:(?:[0-9][0-9']*\\.?[0-9']*)|(?:\\.[0-9']+))(?:(?:e|E)(?:\\+|-)?[0-9']+)?)(?:L|l|UL|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
+	numeric constant:\"(?<!\\Y)(?:(?:0(?:x|X)[0-9a-fA-F][0-9a-fA-F']*)|(?:(?:[0-9][0-9']*\\.?[0-9']*)|(?:\\.[0-9']+))(?:(?:e|E)(?:\\+|-)?[0-9']+)?)(?:LL?|ll?|ULL?|ull?|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
 	character constant:\"(?:L|u|U|u8)?'\":\"'\":\"[^\\\\].{10}\":Character Const::D\n\
 	keywords 1 - storage:\"<(?:register|static|extern|thread_local|mutable)>\":::Storage Type::D\n\
 	keywords 2 - declerations:\"<(?:class|typename|template|friend|virtual|inline|explicit|operator|public|private|protected|const|volatile|typedef|struct|union|enum|asm|override|final|decltype|constexpr|constinit|consteval|noexcept|export|import|module|using|namespace|concept|requires)>\":::Keyword::D\n\

--- a/source/highlightData.c
+++ b/source/highlightData.c
@@ -243,7 +243,7 @@ static char *DefaultPatternSets[] = {
 	Gawk builtin variables:\"\"\"<(ARGIND|ERRNO|RT|IGNORECASE|FIELDWIDTHS)>\"\"\":::Storage Type::D\n\
 	Field:\"\\$[0-9a-zA-Z_]+|\\$[ \\t]*\\([^,;]*\\)\":::Storage Type::D\n\
 	BeginEnd:\"<(BEGIN|END)>\":::Preprocessor1::D\n\
-	Numeric constant:\"(?<!\\Y)((0(x|X)[0-9a-fA-F]*)|[0-9.]+((e|E)(\\+|-)?)?[0-9]*)(L|l|UL|ul|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
+	Numeric constant:\"(?<!\\Y)((0(x|X)[0-9a-fA-F]*)|[0-9.]+((e|E)(\\+|-)?)?[0-9]*)(L|l|UL|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
 	String pattern:\"~[ \\t]*\"\"\":\"\"\"\":\"\\n\":Preprocessor::\n\
 	String pattern escape:\"\\\\(.|\\n)\":::Preprocessor:String pattern:\n\
 	newline escape:\"\\\\$\":::Preprocessor1::\n\
@@ -260,7 +260,7 @@ static char *DefaultPatternSets[] = {
 	preprocessor string:\"(?:L|u|U|u8|R)?\"\"\":\"\"\"\":\"\\n\":Preprocessor1:preprocessor line:\n\
 	prepr string esc chars:\"\\\\(?:.|\\n)\":::String1:preprocessor string:\n\
 	preprocessor keywords:\"<__(?:LINE|FILE|DATE|TIME|STDC|STDC_HOSTED|func)__>\":::Preprocessor::\n\
-	numeric constant:\"(?<!\\Y)(?:(?:0(?:x|X)[0-9a-fA-F][0-9a-fA-F']*)|(?:(?:[0-9][0-9']*\\.?[0-9']*)|(?:\\.[0-9']+))(?:(?:e|E)(?:\\+|-)?[0-9']+)?)(?:LL?|ll?|ULL?|ull?|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
+	numeric constant:\"(?<!\\Y)(?:(?:0b[0-1][0-1']*)|(?:0(?:x|X)[0-9a-fA-F][0-9a-fA-F']*)|(?:(?:[0-9][0-9']*\\.?[0-9']*)|(?:\\.[0-9']+))(?:(?:e|E)(?:\\+|-)?[0-9']+)?)(?:LL?|ll?|ULL?|ull?|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
 	character constant:\"(?:L|u|U|u8)?'\":\"'\":\"[^\\\\].{10}\":Character Const::D\n\
 	keywords 1 - storage:\"<(?:register|static|extern|thread_local|mutable)>\":::Storage Type::D\n\
 	keywords 2 - declerations:\"<(?:class|typename|template|friend|virtual|inline|explicit|operator|public|private|protected|const|volatile|typedef|struct|union|enum|asm|override|final|decltype|constexpr|constinit|consteval|noexcept|export|import|module|using|namespace|concept|requires)>\":::Keyword::D\n\

--- a/source/highlightData.c
+++ b/source/highlightData.c
@@ -251,22 +251,24 @@ static char *DefaultPatternSets[] = {
     "C++:1:0{\n\
 	comment:\"/\\*\":\"\\*/\"::Comment::\n\
 	cplus comment:\"//\":\"(?<!\\\\)$\"::Comment::\n\
-	string:\"L?\"\"\":\"\"\"\":\"\\n\":String::\n\
+	string:\"(?:L|u|U|u8|R)?\"\"\":\"\"\"\":\"\\n\":String::\n\
 	preprocessor line:\"^\\s*#\\s*(?:include|define|if|ifn?def|line|error|else|endif|elif|undef|pragma)>\":\"$\"::Preprocessor::\n\
 	string escape chars:\"\\\\(?:.|\\n)\":::String1:string:\n\
 	preprocessor esc chars:\"\\\\(?:.|\\n)\":::Preprocessor1:preprocessor line:\n\
 	preprocessor comment:\"/\\*\":\"\\*/\"::Comment:preprocessor line:\n\
 	preproc cplus comment:\"//\":\"$\"::Comment:preprocessor line:\n\
-    	preprocessor string:\"L?\"\"\":\"\"\"\":\"\\n\":Preprocessor1:preprocessor line:\n\
-    	prepr string esc chars:\"\\\\(?:.|\\n)\":::String1:preprocessor string:\n\
-	preprocessor keywords:\"<__(?:LINE|FILE|DATE|TIME|STDC)__>\":::Preprocessor::\n\
-	preprocessor keywords c++11:\"<__func__|__STDC_HOSTED__|_Pragma>\":::Preprocessor::\n\
-	character constant:\"L?'\":\"'\":\"[^\\\\][^']\":Character Const::\n\
-	numeric constant:\"(?<!\\Y)(?:(?:0(?:x|X)[0-9a-fA-F]*)|(?:(?:[0-9]+\\.?[0-9]*)|(?:\\.[0-9]+))(?:(?:e|E)(?:\\+|-)?[0-9]+)?)(?:L|l|UL|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
-	storage keyword:\"<(?:class|typename|typeid|template|friend|virtual|inline|explicit|operator|public|private|protected|const|extern|auto|register|static|mutable|unsigned|signed|volatile|char|double|float|int|long|short|bool|wchar_t|void|typedef|struct|union|enum|asm|export)>\":::Storage Type::D\n\
-	storage keyword c++11:\"<(?:override|final|decltype|constexpr|noexcept)>\":::Storage Type::D\n\
-	keyword:\"<(?:new|delete|this|return|goto|if|else|case|default|switch|break|continue|while|do|for|try|catch|throw|sizeof|true|false|namespace|using|dynamic_cast|static_cast|reinterpret_cast|const_cast)>\":::Keyword::D\n\
-	keyword c++11:\"<(?:nullptr|static_assert|alignof)>\":::Keyword::D\n\
+	preprocessor string:\"(?:L|u|U|u8|R)?\"\"\":\"\"\"\":\"\\n\":Preprocessor1:preprocessor line:\n\
+	prepr string esc chars:\"\\\\(?:.|\\n)\":::String1:preprocessor string:\n\
+	preprocessor keywords:\"<__(?:LINE|FILE|DATE|TIME|STDC|STDC_HOSTED|func)__>\":::Preprocessor::\n\
+	numeric constant:\"(?<!\\Y)(?:(?:0(?:x|X)[0-9a-fA-F][0-9a-fA-F']*)|(?:(?:[0-9][0-9']*\\.?[0-9']*)|(?:\\.[0-9']+))(?:(?:e|E)(?:\\+|-)?[0-9']+)?)(?:L|l|UL|ul|u|U|F|f)?(?!\\Y)\":::Numeric Const::D\n\
+	character constant:\"(?:L|u|U|u8)?'\":\"'\":\"[^\\\\].{10}\":Character Const::D\n\
+	keywords 1 - storage:\"<(?:register|static|extern|thread_local|mutable)>\":::Storage Type::D\n\
+	keywords 2 - declerations:\"<(?:class|typename|template|friend|virtual|inline|explicit|operator|public|private|protected|const|volatile|typedef|struct|union|enum|asm|override|final|decltype|constexpr|constinit|consteval|noexcept|export|import|module|using|namespace|concept|requires)>\":::Keyword::D\n\
+	keywords 3 - types:\"<(?:auto|unsigned|signed|char|double|float|int|long|short|bool|wchar_t|void|nullptr_t|char8_t|char16_t|char32_t)>\":::Storage Type::D\n\
+	keywords 4 - control flow:\"<(?:return|goto|if|else|case|default|switch|break|continue|while|do|for|try|catch|throw)>\":::Keyword::D\n\
+	keywords 5 - misc:\"<(?:new|delete|this|sizeof|true|false|dynamic_cast|static_cast|reinterpret_cast|const_cast|nullptr|static_assert|alignof|alignas|typeid|default)>\":::Keyword::D\n\
+	keywords 6 - alternate operators:\"<(?:and|and_eq|compl|not|not_eq|or|or_eq|xor|xor_eq)>\":::Operator::D\n\
+	keywords 7 - co-routines:\"<co_(?:await|return|yield)>\":::Keyword::D\n\
 	braces:\"[{}]\":::Keyword::D}",
     "C:1:0 {\n\
     	comment:\"/\\*\":\"\\*/\"::Comment::\n\


### PR DESCRIPTION
- add keywords up to C++20
- add UTF-8 and UTF-16 char and string literals prefixes
- add raw string prefix (R)
- add support for grouping separators in numeric literals (e.g. 0x0123'ABCD)
- add support for binary literals
- add support for alternate operators
- try the best to group the keywords into categories (not always working, e.g. for the `default` keyword)