### PR TITLE
manually create link to xnedit in AppImage packaging

### DIFF
--- a/resources/AppImage/makeAppDir.sh
+++ b/resources/AppImage/makeAppDir.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# makeAppDir.sh: this script generate the AppDir for a binary.
+# makeAppDir.sh: this script generate the AppDir for a binary
 #
 # Copyright 2023 Valerio Messina
 # makeAppDir.sh is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 #
 # Syntax: $ makeAppDir.sh XNEdit source/xnedit resources/desktop Linux [32|64]
 #
-ver="2023-06-27"
+ver="2023-07-02"
 echo "makeAppDir.sh v.${ver}: generating the AppDir for a binary"
 flag=0 # check for common external dependancy compliance
 for extCmd in basename chmod cp getconf ls mkdir mv rm uname wget ; do
@@ -96,7 +96,13 @@ if (test "$PKG" = "Linux" && (test "$CPU" = "x86_64" || test "$CPU" = "i686")) t
          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
          chmod +x linuxdeploy-x86_64.AppImage
       fi
-      linuxdeploy-x86_64.AppImage -e ${BIN} --appdir ${DIR} -i ${RES}/${NAME}.png -d ${RES}/${NAME}.desktop --output appimage
+      linuxdeploy-x86_64.AppImage -e ${BIN} --appdir ${DIR} -i ${RES}/${NAME}.png -d ${RES}/${NAME}.desktop
+      cwd=`pwd`
+      cd ${DIR}
+      rm AppRun
+      ln -s usr/bin/xnedit AppRun
+      cd "$cwd"
+      linuxdeploy-x86_64.AppImage --appdir ${DIR} --output appimage
       echo ""
       ls -l ${APP}-*-x86_64.AppImage
       #mv ${APP}-*-x86_64.AppImage ../${APP}-x86_64.AppImage
@@ -108,7 +114,13 @@ if (test "$PKG" = "Linux" && (test "$CPU" = "x86_64" || test "$CPU" = "i686")) t
          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-i386.AppImage"
          chmod +x linuxdeploy-i386.AppImage
       fi
-      linuxdeploy-i386.AppImage -e ${BIN} --appdir ${DIR} -i ${RES}/${NAME}.png -d ${RES}/${NAME}.desktop --output appimage
+      linuxdeploy-i386.AppImage -e ${BIN} --appdir ${DIR} -i ${RES}/${NAME}.png -d ${RES}/${NAME}.desktop
+      cwd=`pwd`
+      cd ${DIR}
+      rm AppRun
+      ln -s usr/bin/xnedit AppRun
+      cd "$cwd"
+      linuxdeploy-i386.AppImage --appdir ${DIR} --output appimage
       echo ""
       ls -l ${APP}-*-i386.AppImage
       #mv ${APP}-*-i386.AppImage ../${APP}-i386.AppImage


### PR DESCRIPTION
as workaround to linuxdeploy link to xnc