### PR TITLE
Add "Selection Length" to the status bar

### DIFF
--- a/source/window.c
+++ b/source/window.c
@@ -3459,6 +3459,11 @@ static int updateLineNumDisp(WindowInfo* window)
 void UpdateStatsLine(WindowInfo *window)
 {
     int line, pos, colNum;
+	int byteLength;
+	long charCount = 0;
+	long offset = 0;
+	unsigned char current;
+
 	char * selection;
     char *string, *format, slinecol[42];
     Widget statW = window->statsLine;
@@ -3493,8 +3498,26 @@ void UpdateStatsLine(WindowInfo *window)
         if(nCursors == 1) {
 
 		selection = GetAnySelection(window);
-		if (selection != NULL) {	
-            snprintf(slinecol, 42, "S: %d L: %d  C: %d", strlen(selection), line, colNum);
+		if (selection != NULL) {
+			byteLength = strlen(selection);
+			while (offset < byteLength) {
+				current = selection[offset];
+
+    			if(current >= 240) {
+					offset += 4;
+    			} else if(current >= 224) {
+        			offset += 3;
+    			} else if(current > 192) {
+					offset += 2;
+    			} else {
+					offset ++;
+				}
+					charCount++;
+			}
+
+		
+			
+            snprintf(slinecol, 42, "S: %d L: %d  C: %d", charCount, line, colNum);
 		} else {
 	        snprintf(slinecol, 32, "S: --- L: %d  C: %d", line, colNum);
 			}

--- a/source/window.c
+++ b/source/window.c
@@ -714,7 +714,7 @@ WindowInfo *CreateWindow(const char *name, char *geometry, int iconic)
     /* A separate display of the line/column number */
     window->statsLineColNo = XtVaCreateManagedWidget("statsLineColNo",
             xmLabelWidgetClass, window->statsLineForm,
-            XmNlabelString, s1=XmStringCreateSimple("L: ---  C: ---"),
+            XmNlabelString, s1=XmStringCreateSimple("S: --- L: ---  C: ---"),
             XmNshadowThickness, 0,
             XmNmarginHeight, 2,
             XmNtraversalOn, False,
@@ -3459,7 +3459,8 @@ static int updateLineNumDisp(WindowInfo* window)
 void UpdateStatsLine(WindowInfo *window)
 {
     int line, pos, colNum;
-    char *string, *format, slinecol[32];
+	char * selection;
+    char *string, *format, slinecol[42];
     Widget statW = window->statsLine;
     XmString xmslinecol;
 #ifdef SGI_CUSTOM
@@ -3484,13 +3485,19 @@ void UpdateStatsLine(WindowInfo *window)
         sprintf(string, "%s%s%s %d bytes", window->path, window->filename,
                 format, window->buffer->length);
         if(nCursors == 1) {
-            snprintf(slinecol, 32, "L: ---  C: ---");
+            snprintf(slinecol, 42, "S: --- L: ---  C: ---");
         } else {
             snprintf(slinecol, 32, "%d cursors", nCursors);
         }
     } else {
         if(nCursors == 1) {
-            snprintf(slinecol, 32, "L: %d  C: %d", line, colNum);
+
+		selection = GetAnySelection(window);
+		if (selection != NULL) {	
+            snprintf(slinecol, 42, "S: %d L: %d  C: %d", strlen(selection), line, colNum);
+		} else {
+	        snprintf(slinecol, 32, "S: --- L: %d  C: %d", line, colNum);
+			}
         } else {
             snprintf(slinecol, 32, "%d cursors", nCursors);
         }


### PR DESCRIPTION
Shows the length of the current selection in the status bar.  This is useful for dealing with fixed-width data files, where you might want to select *exactly* N characters to cover a specific field.