### PR TITLE
Adds support to both page and zoom using the mouse scroll wheel — resolves #170

### DIFF
--- a/source/preferences.c
+++ b/source/preferences.c
@@ -413,7 +413,7 @@ static struct prefData {
 				   when it exceeds UNDO_OP_TRIMTO in length */
     
     int zoomStep;
-    int zoomCtrlMouseWheel;     /* 1 = change font size with ctrl+mousewheel, page with shift+ctrl+mousewheel, 0 = actions swapped */
+    int zoomCtrlMouseWheel;     /* 0 = page with ctrl+mousewheel, change font size with shift+ctrl+mousewheel, 1 = actions swapped */
     int sortTabs;		/* sort tabs alphabetically */
     int repositionDialogs;	/* w. to reposition dialogs under the pointer */
     int autoScroll;             /* w. to autoscroll near top/bottom of screen */
@@ -1005,7 +1005,7 @@ static PrefDescripRec PrefDescrip[] = {
     	&PrefData.iSearchLine, NULL, True},
     {"zoomStep", "ZoomStep", PREF_INT, "1",
     	&PrefData.zoomStep, NULL, True},
-    {"zoomCtrlMouseWheel", "ZoomCtrlMouseWheel", PREF_INT, "1",
+    {"zoomCtrlMouseWheel", "ZoomCtrlMouseWheel", PREF_INT, "0",
     	&PrefData.zoomCtrlMouseWheel, NULL, True},
     {"undoPurgeLimit", "UndoPurgeLimit", PREF_INT, "50000000",
     	&PrefData.undoPurgeLimit, NULL, True},
@@ -9030,9 +9030,9 @@ void MiscSettingsDialog(WindowInfo *window) {
             NULL);
     XmStringFree(s1);
     
-    Widget zoomMouseWheelWrapper;
+    Widget pageZoomMouseWheelWrapper;
     
-    zoomMouseWheelWrapper = XtVaCreateManagedWidget("zoomMouseWheelWrapper", xmRowColumnWidgetClass,
+    pageZoomMouseWheelWrapper = XtVaCreateManagedWidget("pageZoomMouseWheelWrapper", xmRowColumnWidgetClass,
             md.form,
             XmNorientation, XmVERTICAL,
             XmNpacking, XmPACK_TIGHT,
@@ -9045,25 +9045,25 @@ void MiscSettingsDialog(WindowInfo *window) {
             XmNbottomWidget, md.edUndoOpLimit,
             NULL);
     
-    md.edZoomMouseWheelDefaultBehavior = XtVaCreateManagedWidget("CtrlZoom_ShiftCtrlPage",
-            xmToggleButtonWidgetClass, zoomMouseWheelWrapper,
+    md.edZoomMouseWheelInvertedBehavior = XtVaCreateManagedWidget("CtrlPage_ShiftCtrlZoom",
+            xmToggleButtonWidgetClass, pageZoomMouseWheelWrapper,
             XmNset, True,
             XmNmarginHeight, 0,
-            XmNlabelString, s1=XmStringCreateLocalized("Zoom with Ctrl+Mousewheel\nPage with Shift+Ctrl+Mousewheel"),
+            XmNlabelString, s1=XmStringCreateLocalized("Page with Ctrl+Mousewheel\nZoom with Shift+Ctrl+Mousewheel"),
             NULL);
     XmStringFree(s1);
     
-    md.edZoomMouseWheelInvertedBehavior = XtVaCreateManagedWidget("CtrlPage_ShiftCtrlZoom",
-            xmToggleButtonWidgetClass, zoomMouseWheelWrapper,
+    md.edZoomMouseWheelDefaultBehavior = XtVaCreateManagedWidget("CtrlZoom_ShiftCtrlPage",
+            xmToggleButtonWidgetClass, pageZoomMouseWheelWrapper,
             XmNmarginHeight, 5,
-            XmNlabelString, s1=XmStringCreateLocalized("Page with Ctrl+Mousewheel\nZoom with Shift+Ctrl+Mousewheel"),
+            XmNlabelString, s1=XmStringCreateLocalized("Zoom with Ctrl+Mousewheel\nPage with Shift+Ctrl+Mousewheel"),
             NULL);
     XmStringFree(s1);
     
     md.edUndoOpLimit = XtVaCreateManagedWidget("miscTextField", XNEtextfieldWidgetClass, md.form,
             XmNrightAttachment, XmATTACH_FORM,
             XmNtopAttachment, XmATTACH_WIDGET,
-            XmNtopWidget, zoomMouseWheelWrapper,
+            XmNtopWidget, pageZoomMouseWheelWrapper,
             XmNtopOffset, 8,
             NULL);
     
@@ -9073,7 +9073,7 @@ void MiscSettingsDialog(WindowInfo *window) {
             XmNleftAttachment, XmATTACH_FORM,
             XmNleftOffset, 8,
             XmNtopAttachment, XmATTACH_WIDGET,
-            XmNtopWidget, zoomMouseWheelWrapper,
+            XmNtopWidget, pageZoomMouseWheelWrapper,
             XmNtopOffset, 8,
             XmNbottomAttachment, XmATTACH_OPPOSITE_WIDGET,
             XmNbottomWidget, md.edUndoOpLimit,

--- a/source/preferences.c
+++ b/source/preferences.c
@@ -8620,12 +8620,12 @@ static void mdApplyCB(Widget w, XtPointer clientData, XtPointer callData) {
     XtFree(zoomStepStr);
 
     Boolean edZoomMouseWheel;
-    XtVaGetValues(md.edZoomMouseWheelDefaultBehavior, XmNset, &edZoomMouseWheel, NULL);
+    XtVaGetValues(md.edZoomMouseWheelInvertedBehavior, XmNset, &edZoomMouseWheel, NULL);
     SetPrefZoomCtrlMouseWheel(edZoomMouseWheel);
     if (edZoomMouseWheel) {
-        RadioButtonChangeState(md.edZoomMouseWheelDefaultBehavior, True, True);
-    } else {
         RadioButtonChangeState(md.edZoomMouseWheelInvertedBehavior, True, True);
+    } else {
+        RadioButtonChangeState(md.edZoomMouseWheelDefaultBehavior, True, True);
     }
 
     long undoOpLimit;
@@ -9045,7 +9045,7 @@ void MiscSettingsDialog(WindowInfo *window) {
             XmNbottomWidget, md.edUndoOpLimit,
             NULL);
     
-    md.edZoomMouseWheelInvertedBehavior = XtVaCreateManagedWidget("CtrlPage_ShiftCtrlZoom",
+    md.edZoomMouseWheelDefaultBehavior = XtVaCreateManagedWidget("CtrlPage_ShiftCtrlZoom",
             xmToggleButtonWidgetClass, pageZoomMouseWheelWrapper,
             XmNset, True,
             XmNmarginHeight, 0,
@@ -9053,7 +9053,7 @@ void MiscSettingsDialog(WindowInfo *window) {
             NULL);
     XmStringFree(s1);
     
-    md.edZoomMouseWheelDefaultBehavior = XtVaCreateManagedWidget("CtrlZoom_ShiftCtrlPage",
+    md.edZoomMouseWheelInvertedBehavior = XtVaCreateManagedWidget("CtrlZoom_ShiftCtrlPage",
             xmToggleButtonWidgetClass, pageZoomMouseWheelWrapper,
             XmNmarginHeight, 5,
             XmNlabelString, s1=XmStringCreateLocalized("Zoom with Ctrl+Mousewheel\nPage with Shift+Ctrl+Mousewheel"),
@@ -9256,9 +9256,9 @@ void MiscSettingsDialog(WindowInfo *window) {
     XmStringFree(s1);
     
     if (GetPrefZoomCtrlMouseWheel()) {
-        RadioButtonChangeState(md.edZoomMouseWheelDefaultBehavior, True, True);
-    } else {
         RadioButtonChangeState(md.edZoomMouseWheelInvertedBehavior, True, True);
+    } else {
+        RadioButtonChangeState(md.edZoomMouseWheelDefaultBehavior, True, True);
     }
     
     

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -82,8 +82,6 @@ int GetPrefZoomStep(void);
 void SetPrefZoomStep(int step);
 int GetPrefZoomCtrlMouseWheel(void);
 void SetPrefZoomCtrlMouseWheel(Boolean s);
-int GetPrefZoomCtrlMouseWheelInvert(void);
-void SetPrefZoomCtrlMouseWheelInvert(Boolean s);
 void SetPrefSortTabs(int state);
 int GetPrefSortTabs(void);
 void SetPrefTabBarHideOne(int state);

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -82,6 +82,8 @@ int GetPrefZoomStep(void);
 void SetPrefZoomStep(int step);
 int GetPrefZoomCtrlMouseWheel(void);
 void SetPrefZoomCtrlMouseWheel(Boolean s);
+int GetPrefZoomCtrlMouseWheelInvert(void);
+void SetPrefZoomCtrlMouseWheelInvert(Boolean s);
 void SetPrefSortTabs(int state);
 int GetPrefSortTabs(void);
 void SetPrefTabBarHideOne(int state);

--- a/source/text.c
+++ b/source/text.c
@@ -3971,14 +3971,14 @@ static void scrollUpAP(Widget w, XEvent *event, String *args,
     textDisp *textD = ((TextWidget)w)->text.textD;
     int topLineNum, horizOffset, nLines;
     
-    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3) {
-        if (GetPrefZoomCtrlMouseWheelInvert() ) {
-            if (!strcmp(args[2], "alt_zoom_shifted") ) {
+    if(*nArgs == 3) {
+        if (GetPrefZoomCtrlMouseWheel()) {
+            if (!strcmp(args[2], "alt_zoom")) {
                 zoomInAP(w, event, args, nArgs);
                 return;
             }
         } else {
-            if (!strcmp(args[2], "alt_zoom")) {
+            if (!strcmp(args[2], "alt_zoom_shifted") ) {
                 zoomInAP(w, event, args, nArgs);
                 return;
             }
@@ -4006,14 +4006,14 @@ static void scrollDownAP(Widget w, XEvent *event, String *args,
     textDisp *textD = ((TextWidget)w)->text.textD;
     int topLineNum, horizOffset, nLines;
 
-    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3) {
-        if (GetPrefZoomCtrlMouseWheelInvert() ) {
-            if (!strcmp(args[2], "alt_zoom_shifted") ) {
+    if(*nArgs == 3) {
+        if (GetPrefZoomCtrlMouseWheel()) {
+            if (!strcmp(args[2], "alt_zoom")) {
                 zoomOutAP(w, event, args, nArgs);
                 return;
             }
         } else {
-            if (!strcmp(args[2], "alt_zoom")) {
+            if (!strcmp(args[2], "alt_zoom_shifted") ) {
                 zoomOutAP(w, event, args, nArgs);
                 return;
             }

--- a/source/text.c
+++ b/source/text.c
@@ -471,14 +471,16 @@ static char defaultTranslations[] =
     "<FocusIn>: focusIn()\n"
     "<FocusOut>: focusOut()\n"
     /* Support for mouse wheel in XFree86 */
-    "Shift<Btn4Down>,<Btn4Up>: scroll_up(1)\n"
-    "Shift<Btn5Down>,<Btn5Up>: scroll_down(1)\n"
-    "Ctrl<Btn4Down>,<Btn4Up>: scroll_up(1, pages, alt_zoom)\n"
-    "Ctrl<Btn5Down>,<Btn5Up>: scroll_down(1, pages, alt_zoom)\n"
-    "<Btn4Down>,<Btn4Up>,<MotionNotify>(1+): extend_adjust()\n"
-    "<Btn5Down>,<Btn5Up>,<MotionNotify>(1+): extend_adjust()\n"
-    "<Btn4Down>,<Btn4Up>: scroll_up(5)\n"
-    "<Btn5Down>,<Btn5Up>: scroll_down(5)\n";
+    "~Ctrl Shift<Btn4Down>,<Btn4Up>: scroll_up(1)\n"
+    "~Ctrl Shift<Btn5Down>,<Btn5Up>: scroll_down(1)\n"
+    "~Shift Ctrl <Btn4Down>,<Btn4Up>: scroll_up(1, pages, alt_zoom)\n"
+    "~Shift Ctrl <Btn5Down>,<Btn5Up>: scroll_down(1, pages, alt_zoom)\n"
+    "Shift Ctrl <Btn4Down>,<Btn4Up>: scroll_up(1, pages, alt_zoom_shifted)\n"
+    "Shift Ctrl <Btn5Down>,<Btn5Up>: scroll_down(1, pages, alt_zoom_shifted)\n"
+    "~Ctrl <Btn4Down>,<Btn4Up>,<MotionNotify>(1+): extend_adjust()\n"
+    "~Ctrl <Btn5Down>,<Btn5Up>,<MotionNotify>(1+): extend_adjust()\n"
+    "~Ctrl <Btn4Down>,<Btn4Up>: scroll_up(5)\n"
+    "~Ctrl <Btn5Down>,<Btn5Up>: scroll_down(5)\n";
      /* some of the translations from the Motif text widget were not picked up:
 	  :<KeyPress>osfSelect: set-anchor()\n\
 	  :<KeyPress>osfActivate: activate()\n\
@@ -3969,9 +3971,18 @@ static void scrollUpAP(Widget w, XEvent *event, String *args,
     textDisp *textD = ((TextWidget)w)->text.textD;
     int topLineNum, horizOffset, nLines;
     
-    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3 && !strcmp(args[2], "alt_zoom")) {
-        zoomInAP(w, event, args, nArgs);
-        return;
+    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3) {
+        if (GetPrefZoomCtrlMouseWheelInvert() ) {
+            if (!strcmp(args[2], "alt_zoom_shifted") ) {
+                zoomInAP(w, event, args, nArgs);
+                return;
+            }
+        } else {
+            if (!strcmp(args[2], "alt_zoom")) {
+                zoomInAP(w, event, args, nArgs);
+                return;
+            }
+        }
     }
 
     if (*nArgs == 0 || sscanf(args[0], "%d", &nLines) != 1)
@@ -3994,12 +4005,20 @@ static void scrollDownAP(Widget w, XEvent *event, String *args,
 {
     textDisp *textD = ((TextWidget)w)->text.textD;
     int topLineNum, horizOffset, nLines;
-    
-    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3 && !strcmp(args[2], "alt_zoom")) {
-        zoomOutAP(w, event, args, nArgs);
-        return;
-    }
 
+    if(GetPrefZoomCtrlMouseWheel() && *nArgs == 3) {
+        if (GetPrefZoomCtrlMouseWheelInvert() ) {
+            if (!strcmp(args[2], "alt_zoom_shifted") ) {
+                zoomOutAP(w, event, args, nArgs);
+                return;
+            }
+        } else {
+            if (!strcmp(args[2], "alt_zoom")) {
+                zoomOutAP(w, event, args, nArgs);
+                return;
+            }
+        }
+    }
     
     if (*nArgs == 0 || sscanf(args[0], "%d", &nLines) != 1)
     	return;


### PR DESCRIPTION
This PR adds ability to use the mouse scrollwheel to scroll a page at a time (using `Ctrl`+`Shift`+Scroll) when "Zoom with Ctrl+Mousewheel" is active.  See table below for key mappings.  It also adds a new option to swap the behavior of `Ctrl`+Scroll and `Shift`+`Ctrl`+Scroll.

By default the PR code's behavior is close to that of `xnedit`'s current behavior.  By default the same scroll zoom behavior is used.  The default behavior of `Ctrl`+`Shift`+Scroll has been changed though (from 1-line to 1-page scroll).  The labels in the Miscellaneous Settings dialog have also been altered.

### Behavior comparison

#### Code in this pull request

**z** → "Zoom with Ctrl+Mousewheel, Page with Shift+Ctrl+Mousewheel"
**i** → "Invert zoom/page behavior"

| Held | z=0, i=0 | z=0, i=1 | z=1, i=0 | z=1, i=1 |
|---|---|---|---|---|
| (none) | Shift view by 5 lines | Shift view by 5 lines | Shift view by 5 lines | Shift view by 5 lines |
| `Ctrl` | Shift view by 1 page | Shift view by 1 page | **Change font size** | **Shift view by 1 page** |
| `Shift` | Shift view by 1 line | Shift view by 1 line | Shift view by 1 line | Shift view by 1 line |
| `Ctrl` + `Shift` | **Shift view by 1 page** | **Shift view by 1 page** | **Shift view by 1 page** | **Change font size** |

#### Current `xnedit` code

**z** → "Zoom with Ctrl+Mousewheel"

| Held | z=0 | z=1 |
|---|---|---|
| (none) | Shift view by 5 lines | Shift view by 5 lines |
| `Ctrl` | Shift view by 1 page | **Change font size** |
| `Shift` | Shift view by 1 line | Shift view by 1 line |
| `Ctrl` + `Shift` | **Shift view by 1 line** | **Shift view by 1 line** |

---

Resolves #170